### PR TITLE
Improve performance for wav read sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ UpgradeLog*
 *.mpq
 
 .idea
+/.vs


### PR DESCRIPTION
When smaplesToRead reaches 35000 or above, reading a float a time will consumes about 3 seconds, which stalls the whole game.
Should use bunch read to speed up.